### PR TITLE
Make amount of rounds configurable.

### DIFF
--- a/src/main/java/com/iota/curl/IotaCurlHash.java
+++ b/src/main/java/com/iota/curl/IotaCurlHash.java
@@ -32,10 +32,16 @@ public class IotaCurlHash {
 
     private final CurlState curlState = new CurlState();
 
-    public static String iotaCurlHash(final String tx, final int len) {
-        final IotaCurlHash ctx = new IotaCurlHash();
+    private final int rounds;
+
+    public static String iotaCurlHash(final String tx, final int len, int rounds) {
+        final IotaCurlHash ctx = new IotaCurlHash(rounds);
         ctx.doAbsorb(tx.toCharArray(), len);
         return ctx.doFinalize();
+    }
+
+    protected IotaCurlHash(int rounds) {
+        this.rounds = rounds;
     }
 
     /**
@@ -51,7 +57,7 @@ public class IotaCurlHash {
     protected void doHashTransform(int [] state1) {
         int [] state2 = Arrays.copyOf(state1, state1.length);
 
-        for(int r=0; r<27; r++) {
+        for(int r=0; r<rounds; r++) {
             state1[0] = IotaCurlUtils.TRUTH_TABLE[state2[0] + (state2[364] << 2) + 5];
 
             // state1[0] = IotaCurlUtils.invokeBinaryTruthOn(state2[0], state2[364]);

--- a/src/main/java/com/iota/curl/IotaCurlMiner.java
+++ b/src/main/java/com/iota/curl/IotaCurlMiner.java
@@ -121,7 +121,7 @@ public class IotaCurlMiner {
 
     private final char[] powInit(final String tx) {
 
-        final IotaCurlHash ctx = new IotaCurlHash();
+        final IotaCurlHash ctx = new IotaCurlHash(27);
         final char[] trx = tx.toCharArray();
         ctx.doAbsorb(trx, TX_HEADER_SZ);
 

--- a/src/main/java/com/iota/curl/miner/Miner.java
+++ b/src/main/java/com/iota/curl/miner/Miner.java
@@ -63,7 +63,7 @@ public class Miner {
         stdout("txTrytes: %s", tx);
 
         // Print hash.
-        final String hash = IotaCurlHash.iotaCurlHash(tx, TX_LENGTH);
+        final String hash = IotaCurlHash.iotaCurlHash(tx, TX_LENGTH, 27);
         stdout("hash: %s", hash);
     }
 

--- a/src/test/java/com/iota/curl/HashTest.java
+++ b/src/test/java/com/iota/curl/HashTest.java
@@ -17,7 +17,7 @@ public class HashTest {
 
     @Test
     public void shouldHash() {
-        final String hashed = IotaCurlHash.iotaCurlHash(tx, 2673);
+        final String hashed = IotaCurlHash.iotaCurlHash(tx, 2673, 27);
         System.err.println(hashed);
         System.err.println(hash);
         Assert.assertEquals(hash, hashed);
@@ -25,7 +25,7 @@ public class HashTest {
 
     @Test
     public void shouldDoHashTransform() {
-        IotaCurlHash hash = new IotaCurlHash();
+        IotaCurlHash hash = new IotaCurlHash(27);
         int [] state = IntStream.generate(() -> 0).limit(1000).toArray();
         System.err.println(Arrays.toString(state));
         hash.doHashTransform(state);


### PR DESCRIPTION
The old version does only support Curl27 but not Curl81. With the proposed change, any amount of rounds can be applied.